### PR TITLE
Fix double-escaping issue in code block strings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ const tf = async (code: string, id: string, options: PluginOptions): Promise<Tra
         }
 
         if (node.tagName === 'code') {
-          const codeContent = DomUtils.getInnerHTML(node, { decodeEntities: true })
+          const codeContent = DomUtils.getInnerHTML(node, { decodeEntities: false })
           node.attribs.dangerouslySetInnerHTML = `vfm{{ __html: \`${codeContent.replace(/([\\`])/g, '\\$1')}\`}}vfm`
           node.childNodes = []
         }


### PR DESCRIPTION
#524
Analyzed the code to identify the root cause and implemented a fix.

Initially, each code block is wrapped using vfm{{___html: ....}}, where an HTML-escaped string is processed and assigned to the dangerouslySetInnerHTML attribute (as a node attribute, which is a critical detail).

https://github.com/hmsk/vite-plugin-markdown/blob/26e97108120624c8a0f218ea5b15cbde511b108b/src/index.ts#L100-L104

After all nodes are processed, getOuterHTML is used to retrieve another HTML-escaped string. Since the default value of the decodeEntities option is true, the dangerouslySetInnerHTML attribute of the nodes representing each code block undergoes an additional round of escaping.

https://github.com/hmsk/vite-plugin-markdown/blob/26e97108120624c8a0f218ea5b15cbde511b108b/src/index.ts#L113

I believe this double escaping is the root cause of the issue.

A similar change was made in [this commit](https://github.com/hmsk/vite-plugin-markdown/commit/f39b4b31a9ad1701b900672664f0885856b320aa), but the approach taken here is the exact opposite. By setting decodeEntities to false, we can prevent special characters from being escaped again.

This approach worked successfully in my environment. Please review and confirm.